### PR TITLE
Feature python3 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,5 +2,6 @@
 omit =
     */virtualenv/*
     */venv/*
+    */.tox/*
 exclude_lines =
     if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 *.py~
 venv/*
+.tox/*
 build/
 dist/
 jatsgenerator.egg-info

--- a/jatsgenerator/generate.py
+++ b/jatsgenerator/generate.py
@@ -300,7 +300,6 @@ class ArticleXML(object):
 
         # XML
         tagged_string = '<' + tag_name + '>' + title + '</' + tag_name + '>'
-        reparsed = minidom.parseString(tagged_string)
         reparsed = minidom.parseString(tagged_string.encode('utf8'))
 
         root_xml_element = xmlio.append_minidom_xml_to_elementtree_xml(

--- a/jatsgenerator/generate.py
+++ b/jatsgenerator/generate.py
@@ -301,6 +301,7 @@ class ArticleXML(object):
         # XML
         tagged_string = '<' + tag_name + '>' + title + '</' + tag_name + '>'
         reparsed = minidom.parseString(tagged_string)
+        reparsed = minidom.parseString(tagged_string.encode('utf8'))
 
         root_xml_element = xmlio.append_minidom_xml_to_elementtree_xml(
             root_xml_element, reparsed
@@ -421,7 +422,7 @@ class ArticleXML(object):
 
         # XML
         tagged_string = '<' + tag_name + '>' + abstract + '</' + tag_name + '>'
-        reparsed = minidom.parseString(tagged_string)
+        reparsed = minidom.parseString(tagged_string.encode('utf8'))
 
         root_xml_element = xmlio.append_minidom_xml_to_elementtree_xml(
             root_xml_element, reparsed

--- a/jatsgenerator/generate.py
+++ b/jatsgenerator/generate.py
@@ -1,16 +1,17 @@
+from __future__ import print_function
 import logging
 import time
 import os
 from xml.etree.ElementTree import Element, SubElement, Comment
 from xml.etree import ElementTree
 from xml.dom import minidom
-from conf import config, parse_raw_config
+from jatsgenerator.conf import config, parse_raw_config
 from elifetools import utils as etoolsutils
 from elifetools import xmlio
 from elifearticle import utils as eautils
 import ejpcsvparser.parse as parse
 import ejpcsvparser.csv_data as data
-import settings
+import ejpcsvparser.settings as settings
 
 
 logger = logging.getLogger('xml_gen')
@@ -438,7 +439,7 @@ class ArticleXML(object):
         """
         aff_id = None
 
-        for key, value in self.author_affs.iteritems():
+        for key, value in self.author_affs.items():
             if self.compare_aff(affiliation, value):
                 aff_id = key
         if not aff_id:
@@ -552,7 +553,7 @@ class ArticleXML(object):
 
         # Add the aff tags
         if contrib_type != "editor":
-            for key, value in self.author_affs.iteritems():
+            for key, value in self.author_affs.items():
                 aff_id = "aff" + str(key)
                 self.set_aff(self.contrib_group, value, contrib_type, aff_id)
 
@@ -832,7 +833,7 @@ def build_xml_to_disk(article_id, article=None, config_section="elife", add_comm
         try:
             write_xml_to_disk(article_xml, filename, output_dir=settings.TARGET_OUTPUT_DIR)
             logger.info("xml written for " + str(article_id))
-            print "written " + str(article_id)
+            print("written " + str(article_id))
             return True
         except:
             logger.error("could not write xml for " + str(article_id))

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-set -e
 
-virtualenv venv
-source venv/bin/activate
-pip install -r requirements.txt
+tox
+. .tox/py35/bin/activate
 pip install coveralls
-coverage run -m unittest discover tests
 COVERALLS_REPO_TOKEN=$(cat /etc/coveralls/tokens/jats-generator) coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-git+https://github.com/elifesciences/elife-tools.git@5eecbc2d94905b028b4ae339b7a7475bf1a71bf4#egg=elifetools
-git+https://github.com/elifesciences/elife-article.git@fe3d0a549a280eec229dd935cb537511c245be99#egg=elifearticle
-git+https://github.com/elifesciences/ejp-csv-parser.git@da55770eb754158477128c24f08a4d7727aa5279#egg=ejpcsvparser
-GitPython==0.3.2.1
+git+https://github.com/elifesciences/elife-tools.git@352226be98e6adec488406268acb50a9b76876db#egg=elifetools
+git+https://github.com/elifesciences/elife-article.git@e83828ab496a66bacd713879f5ee9c35eceeeb7c#egg=elifearticle
+git+https://github.com/elifesciences/ejp-csv-parser.git@5b9b930857f3ee8bbecf713817134d38362972ed#egg=ejpcsvparser
+GitPython==2.1.7
 configparser==3.5.0
 mock==1.3.0
+coverage==4.4.2

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
         ]
     )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,7 +3,6 @@ import time
 import os
 from mock import Mock, patch
 from jatsgenerator import generate
-from elifearticle.utils import unicode_value
 from elifearticle.article import ArticleDate
 
 TEST_BASE_PATH = os.path.dirname(os.path.abspath(__file__)) + os.sep
@@ -90,7 +89,7 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         self.assertIsNotNone(article_xml, "count not generate xml for the article")
         self.assertFalse('other authors declare that no competing interests exist' in
-                         unicode_value(article_xml.output_xml(pretty=True, indent='\t')))
+                         article_xml.output_xml(pretty=True, indent='\t').decode('utf8'))
 
     def test_set_copyright_authors(self):
         "start with an article then change the authors for test coverage for different input"
@@ -99,7 +98,7 @@ class TestGenerate(unittest.TestCase):
         # test the value as is with more than two authors
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<copyright-holder>Schuman et al</copyright-holder>' in unicode_value(article_xml.output_xml()))
+            '<copyright-holder>Schuman et al</copyright-holder>' in article_xml.output_xml().decode('utf8'))
         # set authors to be exactly two
         for index, author in enumerate(article.contributors):
             if index > 1:
@@ -107,18 +106,18 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
             '<copyright-holder>Schuman &amp; Barthel</copyright-holder>'
-            in unicode_value(article_xml.output_xml()))
+            in article_xml.output_xml().decode('utf8'))
         # set authors to be exactly one
         for index, author in enumerate(article.contributors):
             if index > 0:
                 del article.contributors[index]
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<copyright-holder>Schuman</copyright-holder>' in unicode_value(article_xml.output_xml()))
+            '<copyright-holder>Schuman</copyright-holder>' in article_xml.output_xml().decode('utf8'))
         # no authors
         article.contributors = []
         article_xml = generate.build_xml(article_id, article)
-        self.assertTrue('<copyright-holder/>' in unicode_value(article_xml.output_xml()))
+        self.assertTrue('<copyright-holder/>' in article_xml.output_xml().decode('utf8'))
 
     def test_set_copyright_license_date(self):
         "start with an article then remove the license date"
@@ -132,7 +131,7 @@ class TestGenerate(unittest.TestCase):
         accepted_date_object = ArticleDate("pub", accepted_date)
         article.dates['accepted'] = accepted_date_object
         article_xml = generate.build_xml(article_id, article)
-        self.assertTrue('<copyright-year>2037</copyright-year>' in unicode_value(article_xml.output_xml()))
+        self.assertTrue('<copyright-year>2037</copyright-year>' in article_xml.output_xml().decode('utf8'))
 
     def test_contributor_equal_contrib(self):
         "set equal_contrib on an author to test the output"
@@ -145,13 +144,13 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
             '<contrib contrib-type="author" equal_contrib="yes" id="author-1399">'
-            in unicode_value(article_xml.output_xml()))
+            in article_xml.output_xml().decode('utf8'))
         self.assertTrue(
             '<contrib contrib-type="author" corresp="yes" equal_contrib="yes" id="author-1400">'
-            in unicode_value(article_xml.output_xml()))
+            in article_xml.output_xml().decode('utf8'))
         self.assertTrue(
             '<contrib contrib-type="author" corresp="yes" equal_contrib="yes" id="author-1013">'
-            in unicode_value(article_xml.output_xml()))
+            in article_xml.output_xml().decode('utf8'))
 
     def test_contributor_phone_fax(self):
         "set phone and fax on an author to test the output for test coverage"
@@ -161,8 +160,8 @@ class TestGenerate(unittest.TestCase):
         article.contributors[0].affiliations[0].phone = '555-5555'
         article.contributors[0].affiliations[0].fax = '555-5555'
         article_xml = generate.build_xml(article_id, article)
-        self.assertTrue('<phone>555-5555</phone>' in unicode_value(article_xml.output_xml()))
-        self.assertTrue('<fax>555-5555</fax>' in unicode_value(article_xml.output_xml()))
+        self.assertTrue('<phone>555-5555</phone>' in article_xml.output_xml().decode('utf8'))
+        self.assertTrue('<fax>555-5555</fax>' in article_xml.output_xml().decode('utf8'))
 
     def test_do_display_channel(self):
         "test when the display channel is blank"
@@ -171,7 +170,7 @@ class TestGenerate(unittest.TestCase):
         article.display_channel = None
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<subj-group subj-group-type="display-channel">' not in unicode_value(article_xml.output_xml()))
+            '<subj-group subj-group-type="display-channel">' not in article_xml.output_xml().decode('utf8'))
 
     def test_do_subject_heading(self):
         "test when the article_categories is empty"
@@ -180,7 +179,7 @@ class TestGenerate(unittest.TestCase):
         article.article_categories = []
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<subj-group subj-group-type="heading">' not in unicode_value(article_xml.output_xml()))
+            '<subj-group subj-group-type="heading">' not in article_xml.output_xml().decode('utf8'))
 
     def test_do_article_categories(self):
         "test when there is no display channel or article categories"
@@ -190,7 +189,7 @@ class TestGenerate(unittest.TestCase):
         article.article_categories = []
         article_xml = generate.build_xml(article_id, article)
         # now it should have no <article-categories> section at all
-        self.assertTrue('<article-categories>' not in unicode_value(article_xml.output_xml()))
+        self.assertTrue('<article-categories>' not in article_xml.output_xml().decode('utf8'))
 
     def test_author_keywords(self):
         "test setting author keywords which is currently disabled"
@@ -201,7 +200,7 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         article_xml.set_kwd_group_author_keywords(article_xml.article_meta, article)
         self.assertTrue(
-            '<kwd-group kwd-group-type="author-keywords">' in unicode_value(article_xml.output_xml()))
+            '<kwd-group kwd-group-type="author-keywords">' in article_xml.output_xml().decode('utf8'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -3,6 +3,7 @@ import time
 import os
 from mock import Mock, patch
 from jatsgenerator import generate
+from elifearticle.utils import unicode_value
 from elifearticle.article import ArticleDate
 
 TEST_BASE_PATH = os.path.dirname(os.path.abspath(__file__)) + os.sep
@@ -89,7 +90,7 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         self.assertIsNotNone(article_xml, "count not generate xml for the article")
         self.assertFalse('other authors declare that no competing interests exist' in
-                         article_xml.output_xml(pretty=True, indent='\t'))
+                         unicode_value(article_xml.output_xml(pretty=True, indent='\t')))
 
     def test_set_copyright_authors(self):
         "start with an article then change the authors for test coverage for different input"
@@ -98,7 +99,7 @@ class TestGenerate(unittest.TestCase):
         # test the value as is with more than two authors
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<copyright-holder>Schuman et al</copyright-holder>' in article_xml.output_xml())
+            '<copyright-holder>Schuman et al</copyright-holder>' in unicode_value(article_xml.output_xml()))
         # set authors to be exactly two
         for index, author in enumerate(article.contributors):
             if index > 1:
@@ -106,18 +107,18 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
             '<copyright-holder>Schuman &amp; Barthel</copyright-holder>'
-            in article_xml.output_xml())
+            in unicode_value(article_xml.output_xml()))
         # set authors to be exactly one
         for index, author in enumerate(article.contributors):
             if index > 0:
                 del article.contributors[index]
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<copyright-holder>Schuman</copyright-holder>' in article_xml.output_xml())
+            '<copyright-holder>Schuman</copyright-holder>' in unicode_value(article_xml.output_xml()))
         # no authors
         article.contributors = []
         article_xml = generate.build_xml(article_id, article)
-        self.assertTrue('<copyright-holder/>' in article_xml.output_xml())
+        self.assertTrue('<copyright-holder/>' in unicode_value(article_xml.output_xml()))
 
     def test_set_copyright_license_date(self):
         "start with an article then remove the license date"
@@ -131,7 +132,7 @@ class TestGenerate(unittest.TestCase):
         accepted_date_object = ArticleDate("pub", accepted_date)
         article.dates['accepted'] = accepted_date_object
         article_xml = generate.build_xml(article_id, article)
-        self.assertTrue('<copyright-year>2037</copyright-year>' in article_xml.output_xml())
+        self.assertTrue('<copyright-year>2037</copyright-year>' in unicode_value(article_xml.output_xml()))
 
     def test_contributor_equal_contrib(self):
         "set equal_contrib on an author to test the output"
@@ -144,13 +145,13 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
             '<contrib contrib-type="author" equal_contrib="yes" id="author-1399">'
-            in article_xml.output_xml())
+            in unicode_value(article_xml.output_xml()))
         self.assertTrue(
             '<contrib contrib-type="author" corresp="yes" equal_contrib="yes" id="author-1400">'
-            in article_xml.output_xml())
+            in unicode_value(article_xml.output_xml()))
         self.assertTrue(
             '<contrib contrib-type="author" corresp="yes" equal_contrib="yes" id="author-1013">'
-            in article_xml.output_xml())
+            in unicode_value(article_xml.output_xml()))
 
     def test_contributor_phone_fax(self):
         "set phone and fax on an author to test the output for test coverage"
@@ -160,8 +161,8 @@ class TestGenerate(unittest.TestCase):
         article.contributors[0].affiliations[0].phone = '555-5555'
         article.contributors[0].affiliations[0].fax = '555-5555'
         article_xml = generate.build_xml(article_id, article)
-        self.assertTrue('<phone>555-5555</phone>' in article_xml.output_xml())
-        self.assertTrue('<fax>555-5555</fax>' in article_xml.output_xml())
+        self.assertTrue('<phone>555-5555</phone>' in unicode_value(article_xml.output_xml()))
+        self.assertTrue('<fax>555-5555</fax>' in unicode_value(article_xml.output_xml()))
 
     def test_do_display_channel(self):
         "test when the display channel is blank"
@@ -170,7 +171,7 @@ class TestGenerate(unittest.TestCase):
         article.display_channel = None
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<subj-group subj-group-type="display-channel">' not in article_xml.output_xml())
+            '<subj-group subj-group-type="display-channel">' not in unicode_value(article_xml.output_xml()))
 
     def test_do_subject_heading(self):
         "test when the article_categories is empty"
@@ -179,7 +180,7 @@ class TestGenerate(unittest.TestCase):
         article.article_categories = []
         article_xml = generate.build_xml(article_id, article)
         self.assertTrue(
-            '<subj-group subj-group-type="heading">' not in article_xml.output_xml())
+            '<subj-group subj-group-type="heading">' not in unicode_value(article_xml.output_xml()))
 
     def test_do_article_categories(self):
         "test when there is no display channel or article categories"
@@ -189,7 +190,7 @@ class TestGenerate(unittest.TestCase):
         article.article_categories = []
         article_xml = generate.build_xml(article_id, article)
         # now it should have no <article-categories> section at all
-        self.assertTrue('<article-categories>' not in article_xml.output_xml())
+        self.assertTrue('<article-categories>' not in unicode_value(article_xml.output_xml()))
 
     def test_author_keywords(self):
         "test setting author keywords which is currently disabled"
@@ -200,7 +201,7 @@ class TestGenerate(unittest.TestCase):
         article_xml = generate.build_xml(article_id, article)
         article_xml.set_kwd_group_author_keywords(article_xml.article_meta, article)
         self.assertTrue(
-            '<kwd-group kwd-group-type="author-keywords">' in article_xml.output_xml())
+            '<kwd-group kwd-group-type="author-keywords">' in unicode_value(article_xml.output_xml()))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+skipsdist = True
+envlist = py27,py35
+[testenv]
+deps = -rrequirements.txt
+commands = coverage run -m unittest discover tests


### PR DESCRIPTION
Uses a yet to be merged commit for the ``ejp-csv-parser`` library which has Python 3 support. The modifications here seem to make this library compatible with Python 2.7 and Python 3.5.